### PR TITLE
Parallel multiplication of sparse matrices

### DIFF
--- a/CSparse.Tests/Double/SparseMatrixTest.cs
+++ b/CSparse.Tests/Double/SparseMatrixTest.cs
@@ -231,6 +231,27 @@ namespace CSparse.Tests.Double
 
         [TestCase(2, 2)]
         [TestCase(2, 3)]
+        public void TestMatrixParallelMultiply(int rows, int columns)
+        {
+            var data = MatrixHelper.LoadSparse(rows, columns);
+
+            var A = data.A;
+            var B = data.B;
+
+            var AT = data.AT;
+            var BT = data.BT;
+
+            var actual = AT.ParallelMultiply(B);
+
+            CollectionAssert.AreEqual(data.ATmB.Values, actual.Values);
+
+            actual = A.ParallelMultiply(BT);
+
+            CollectionAssert.AreEqual(data.AmBT.Values, actual.Values);
+        }
+
+        [TestCase(2, 2)]
+        [TestCase(2, 3)]
         public void TestMatrixPermuteColumns(int rows, int columns)
         {
             var p = Permutation.Create(columns, -1);

--- a/CSparse.Tests/Double/SparseMatrixTest.cs
+++ b/CSparse.Tests/Double/SparseMatrixTest.cs
@@ -229,25 +229,35 @@ namespace CSparse.Tests.Double
             CollectionAssert.AreEqual(data.AmBT.Values, actual.Values);
         }
 
-        [TestCase(2, 2)]
-        [TestCase(2, 3)]
-        public void TestMatrixParallelMultiply(int rows, int columns)
+        [Test]
+        public void TestMatrixParallelMultiply()
         {
-            var data = MatrixHelper.LoadSparse(rows, columns);
-
-            var A = data.A;
-            var B = data.B;
-
-            var AT = data.AT;
-            var BT = data.BT;
-
-            var actual = AT.ParallelMultiply(B);
-
-            CollectionAssert.AreEqual(data.ATmB.Values, actual.Values);
-
-            actual = A.ParallelMultiply(BT);
-
-            CollectionAssert.AreEqual(data.AmBT.Values, actual.Values);
+            var data = ResourceLoader.Get<double>("general-40x40.mat");
+            var acs = new CSparse.Storage.CoordinateStorage<double>(40, 400, 40 * 400);
+            for (var k = 0; k < 10; k++)
+            {
+                for (var i = 0; i < 40; i++)
+                {
+                    for (var j = 0; j < 40; j++)
+                    {
+                        acs.At(i, j + 40 * k, data.At(i, j));
+                    }
+                }
+            }
+            var bcs = new CSparse.Storage.CoordinateStorage<double>(400, 40, 40 * 400);
+            for (var k = 0; k < 10; k++)
+            {
+                for (var i = 0; i < 40; i++)
+                {
+                    for (var j = 0; j < 40; j++)
+                    {
+                        bcs.At(i + 40 * k, j, data.At(i, j));
+                    }
+                }
+            }
+            var A = Converter.ToCompressedColumnStorage(acs);
+            var B = Converter.ToCompressedColumnStorage(bcs);
+            CollectionAssert.AreEqual(A.Multiply(B).Values, A.ParallelMultiply(B).Values);
         }
 
         [TestCase(2, 2)]

--- a/CSparse.Tests/Double/SparseMatrixTest.cs
+++ b/CSparse.Tests/Double/SparseMatrixTest.cs
@@ -233,26 +233,17 @@ namespace CSparse.Tests.Double
         public void TestMatrixParallelMultiply()
         {
             var data = ResourceLoader.Get<double>("general-40x40.mat");
-            var acs = new CSparse.Storage.CoordinateStorage<double>(40, 400, 40 * 400);
-            for (var k = 0; k < 10; k++)
+            var acs = new Storage.CoordinateStorage<double>(40, 800, 40 * 800);
+            var bcs = new Storage.CoordinateStorage<double>(800, 40, 800 * 40);
+            // This just exceeds min_total_ops in ParallelMultiply
+            foreach (var item in data.EnumerateIndexed())
             {
-                for (var i = 0; i < 40; i++)
+                int i = item.Item1;
+                int j = item.Item2;
+                for (var k = 0; k < 20; k++)
                 {
-                    for (var j = 0; j < 40; j++)
-                    {
-                        acs.At(i, j + 40 * k, data.At(i, j));
-                    }
-                }
-            }
-            var bcs = new CSparse.Storage.CoordinateStorage<double>(400, 40, 40 * 400);
-            for (var k = 0; k < 10; k++)
-            {
-                for (var i = 0; i < 40; i++)
-                {
-                    for (var j = 0; j < 40; j++)
-                    {
-                        bcs.At(i + 40 * k, j, data.At(i, j));
-                    }
+                    acs.At(i, j + 40 * k, item.Item3);
+                    bcs.At(i + 40 * k, j, item.Item3);
                 }
             }
             var A = Converter.ToCompressedColumnStorage(acs);

--- a/CSparse/Double/SparseMatrix.cs
+++ b/CSparse/Double/SparseMatrix.cs
@@ -425,6 +425,11 @@ namespace CSparse.Double
         {
             int m = this.rowCount;
             int n = other.ColumnCount;
+            int block_size = 16;
+            if (n <= block_size)
+            {
+                return Multiply(other);
+            }
 
             int anz = this.NonZerosCount;
             int bnz = other.NonZerosCount;
@@ -449,8 +454,8 @@ namespace CSparse.Double
             var bi = other.RowIndices;
             var bx = other.Values;
 
-            var block_size = Math.Min(n, 16);
             var nblocks = (n + block_size - 1) / block_size;
+            block_size = (n + nblocks - 1) / nblocks;
             var results = new SparseMatrix[nblocks];
             var indices = new int[nblocks];
             var nresults = 0;

--- a/CSparse/Storage/CompressedColumnStorage.cs
+++ b/CSparse/Storage/CompressedColumnStorage.cs
@@ -393,6 +393,11 @@ namespace CSparse.Storage
         /// <returns>C = A*B, null on error</returns>
         public abstract CompressedColumnStorage<T> Multiply(CompressedColumnStorage<T> other);
 
+        public virtual CompressedColumnStorage<T> ParallelMultiply(CompressedColumnStorage<T> other)
+        {
+            return Multiply(other);
+        }
+
         #endregion
 
         /// <summary>


### PR DESCRIPTION
The method `ParallelMultiply` uses [`Parallel.For`](https://docs.microsoft.com/en-us/dotnet/api/system.threading.tasks.parallel.for?view=netframework-4.8) to speed up matrix multiplication by using multiple CPU cores.

I tested it by multiplying randomly initialized 800x600 and 600x800 matrices with different fractions of non zeros. With a non-zero fraction of 0.5 and above, the parallel approach is about 6 times faster. The total CPU time overhead is about 60% at 0.7 (about 10 parallel threads) and goes up for smaller non-zero fractions, e.g., 95% at 0.4. The break-even point is at a non-zero fraction of 0.03 where both approaches take the same time. With a non-zero fraction of 0.01, the parallel approach takes about 4 times longer.

As the speed-up is larger with less sparse matrices, this would probably also benefit dense matrices.