### PR TITLE
Just added net5.0 for build target framework.

### DIFF
--- a/CSparse.Tests/CSparse.Tests.csproj
+++ b/CSparse.Tests/CSparse.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net5.0</TargetFramework>
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>

--- a/CSparse/CSparse.csproj
+++ b/CSparse/CSparse.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net40;net45;netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>net40;net45;net5.0;netstandard2.0</TargetFrameworks>
     <GeneratePackageOnBuild>false</GeneratePackageOnBuild>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <PackageId>CSparse</PackageId>


### PR DESCRIPTION
Thank you so the amazing package!!!

To use this package for net5.0, I just added net5.0 for build target framework and changed MSTest build target netcoreapp3.1 to net5.0.
I checked the all tests have passed.

If you could accept this request and re-upload it to Nuget, it would be greatly appreciated.