### PR TITLE
add Span<T> methods

### DIFF
--- a/CSparse/CSparse.csproj
+++ b/CSparse/CSparse.csproj
@@ -26,6 +26,10 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="System.Memory" Version="4.5.5" />
+  </ItemGroup>
+
+  <ItemGroup>
     <Compile Update="Properties\Resources.Designer.cs">
       <DesignTime>True</DesignTime>
       <AutoGen>True</AutoGen>

--- a/CSparse/CSparse.csproj
+++ b/CSparse/CSparse.csproj
@@ -26,6 +26,10 @@
   </PropertyGroup>
 
   <ItemGroup>
+      <PackageReference Include="System.Memory" Version="4.5.5" Condition="'$(TargetFramework)' == 'netstandard2.0'"/>
+  </ItemGroup>
+
+  <ItemGroup>
     <Compile Update="Properties\Resources.Designer.cs">
       <DesignTime>True</DesignTime>
       <AutoGen>True</AutoGen>

--- a/CSparse/Complex/DenseMatrix.cs
+++ b/CSparse/Complex/DenseMatrix.cs
@@ -107,7 +107,7 @@ namespace CSparse.Complex
         }
 
         /// <inheritdoc />
-        public override void Multiply(Complex[] x, Complex[] y)
+        public override void Multiply(ReadOnlySpan<Complex> x, Span<Complex> y)
         {
             var A = Values;
 
@@ -128,7 +128,7 @@ namespace CSparse.Complex
         }
 
         /// <inheritdoc />
-        public override void Multiply(Complex alpha, Complex[] x, Complex beta, Complex[] y)
+        public override void Multiply(Complex alpha, ReadOnlySpan<Complex> x, Complex beta, Span<Complex> y)
         {
             var A = Values;
 
@@ -149,7 +149,7 @@ namespace CSparse.Complex
         }
 
         /// <inheritdoc />
-        public override void TransposeMultiply(Complex[] x, Complex[] y)
+        public override void TransposeMultiply(ReadOnlySpan<Complex> x, Span<Complex> y)
         {
             var A = Values;
 
@@ -172,7 +172,7 @@ namespace CSparse.Complex
         }
 
         /// <inheritdoc />
-        public override void TransposeMultiply(Complex alpha, Complex[] x, Complex beta, Complex[] y)
+        public override void TransposeMultiply(Complex alpha, ReadOnlySpan<Complex> x, Complex beta, Span<Complex> y)
         {
             var A = Values;
 

--- a/CSparse/Complex/Factorization/SparseCholesky.cs
+++ b/CSparse/Complex/Factorization/SparseCholesky.cs
@@ -111,7 +111,14 @@ namespace CSparse.Complex.Factorization
         /// </summary>
         /// <param name="input">The right hand side vector, <c>b</c>.</param>
         /// <param name="result">The left hand side vector, <c>x</c>.</param>
-        public void Solve(Complex[] input, Complex[] result)
+        public void Solve(Complex[] input, Complex[] result) => Solve(input.AsSpan(), result.AsSpan());
+
+        /// <summary>
+        /// Solves a system of linear equations, <c>Ax = b</c>.
+        /// </summary>
+        /// <param name="input">The right hand side vector, <c>b</c>.</param>
+        /// <param name="result">The left hand side vector, <c>x</c>.</param>
+        public void Solve(ReadOnlySpan<Complex> input, Span<Complex> result)
         {
             if (input == null) throw new ArgumentNullException(nameof(input));
 

--- a/CSparse/Complex/Factorization/SparseLDL.cs
+++ b/CSparse/Complex/Factorization/SparseLDL.cs
@@ -117,7 +117,14 @@ namespace CSparse.Complex.Factorization
         /// </summary>
         /// <param name="input">Right hand side b.</param>
         /// <param name="result">Solution vector x.</param>
-        public void Solve(Complex[] input, Complex[] result)
+        public void Solve(Complex[] input, Complex[] result) => Solve(input.AsSpan(), result.AsSpan());
+
+        /// <summary>
+        /// Solves a linear system Ax=b, where A is symmetric positive definite.
+        /// </summary>
+        /// <param name="input">Right hand side b.</param>
+        /// <param name="result">Solution vector x.</param>
+        public void Solve(ReadOnlySpan<Complex> input, Span<Complex> result)
         {
             if (input == null) throw new ArgumentNullException(nameof(input));
 

--- a/CSparse/Complex/Factorization/SparseLU.cs
+++ b/CSparse/Complex/Factorization/SparseLU.cs
@@ -115,7 +115,14 @@ namespace CSparse.Complex.Factorization
         /// </summary>
         /// <param name="input">The right hand side vector, <c>b</c>.</param>
         /// <param name="result">The left hand side vector, <c>x</c>.</param>
-        public void Solve(Complex[] input, Complex[] result)
+        public void Solve(Complex[] input, Complex[] result) => Solve(input.AsSpan(), result.AsSpan());
+
+        /// <summary>
+        /// Solves a system of linear equations, <c>Ax = b</c>.
+        /// </summary>
+        /// <param name="input">The right hand side vector, <c>b</c>.</param>
+        /// <param name="result">The left hand side vector, <c>x</c>.</param>
+        public void Solve(ReadOnlySpan<Complex> input, Span<Complex> result)
         {
             if (input == null) throw new ArgumentNullException(nameof(input));
 
@@ -137,7 +144,14 @@ namespace CSparse.Complex.Factorization
         /// </summary>
         /// <param name="input">The right hand side vector, <c>b</c>.</param>
         /// <param name="result">The left hand side vector, <c>x</c>.</param>
-        public void SolveTranspose(Complex[] input, Complex[] result)
+        public void SolveTranspose(Complex[] input, Complex[] result) => SolveTranspose(input.AsSpan(), result.AsSpan());
+
+        /// <summary>
+        /// Solves a system of linear equations, <c>A'x = b</c>.
+        /// </summary>
+        /// <param name="input">The right hand side vector, <c>b</c>.</param>
+        /// <param name="result">The left hand side vector, <c>x</c>.</param>
+        public void SolveTranspose(ReadOnlySpan<Complex> input, Span<Complex> result)
         {
             if (input == null) throw new ArgumentNullException(nameof(input));
 

--- a/CSparse/Complex/Factorization/SparseQR.cs
+++ b/CSparse/Complex/Factorization/SparseQR.cs
@@ -86,7 +86,18 @@ namespace CSparse.Complex.Factorization
         /// Let A be a m-by-n matrix. If m >= n a least-squares problem (min |Ax-b|)
         /// is solved. If m &lt; n the underdetermined system is solved.
         /// </remarks>
-        public override void Solve(Complex[] input, Complex[] result)
+        public override void Solve(Complex[] input, Complex[] result) => Solve(input.AsSpan(), result.AsSpan());
+
+        /// <summary>
+        /// Solves a system of linear equations, <c>Ax = b</c>.
+        /// </summary>
+        /// <param name="input">The right hand side vector, <c>b</c>.</param>
+        /// <param name="result">The left hand side vector, <c>x</c>.</param>
+        /// <remarks>
+        /// Let A be a m-by-n matrix. If m >= n a least-squares problem (min |Ax-b|)
+        /// is solved. If m &lt; n the underdetermined system is solved.
+        /// </remarks>
+        public override void Solve(ReadOnlySpan<Complex> input, Span<Complex> result)
         {
             if (input == null) throw new ArgumentNullException(nameof(input));
 
@@ -134,7 +145,14 @@ namespace CSparse.Complex.Factorization
         /// </summary>
         /// <param name="input">The right hand side vector, <c>b</c>.</param>
         /// <param name="result">The left hand side vector, <c>x</c>.</param>
-        public void SolveTranspose(Complex[] input, Complex[] result)
+        public void SolveTranspose(Complex[] input, Complex[] result) => SolveTranspose(input.AsSpan(), result.AsSpan());
+
+        /// <summary>
+        /// Solves a system of linear equations, <c>A'x = b</c>.
+        /// </summary>
+        /// <param name="input">The right hand side vector, <c>b</c>.</param>
+        /// <param name="result">The left hand side vector, <c>x</c>.</param>
+        public void SolveTranspose(ReadOnlySpan<Complex> input, Span<Complex> result)
         {
             if (input == null) throw new ArgumentNullException(nameof(input));
 

--- a/CSparse/Complex/SolverHelper.cs
+++ b/CSparse/Complex/SolverHelper.cs
@@ -1,6 +1,7 @@
 namespace CSparse.Complex
 {
     using CSparse.Storage;
+    using System;
     using System.Numerics;
 
     /// <summary>
@@ -14,7 +15,15 @@ namespace CSparse.Complex
         /// <param name="L"></param>
         /// <param name="x"></param>
         /// <returns></returns>
-        public static void SolveLower(CompressedColumnStorage<Complex> L, Complex[] x)
+        public static void SolveLower(CompressedColumnStorage<Complex> L, Complex[] x) => SolveLower(L, x.AsSpan());
+
+        /// <summary>
+        /// Solve a lower triangular system by forward elimination, Lx=b.
+        /// </summary>
+        /// <param name="L"></param>
+        /// <param name="x"></param>
+        /// <returns></returns>
+        public static void SolveLower(CompressedColumnStorage<Complex> L, Span<Complex> x)
         {
             int p, j, k, n = L.ColumnCount;
 
@@ -41,7 +50,15 @@ namespace CSparse.Complex
         /// <param name="L"></param>
         /// <param name="x"></param>
         /// <returns></returns>
-        public static void SolveLowerTranspose(CompressedColumnStorage<Complex> L, Complex[] x)
+        public static void SolveLowerTranspose(CompressedColumnStorage<Complex> L, Complex[] x) => SolveLowerTranspose(L, x.AsSpan());
+
+        /// <summary>
+        /// Solve L'x=b where x and b are dense.
+        /// </summary>
+        /// <param name="L"></param>
+        /// <param name="x"></param>
+        /// <returns></returns>
+        public static void SolveLowerTranspose(CompressedColumnStorage<Complex> L, Span<Complex> x)
         {
             int p, j, k, n = L.ColumnCount;
 
@@ -68,7 +85,15 @@ namespace CSparse.Complex
         /// <param name="U"></param>
         /// <param name="x"></param>
         /// <returns></returns>
-        public static void SolveUpper(CompressedColumnStorage<Complex> U, Complex[] x)
+        public static void SolveUpper(CompressedColumnStorage<Complex> U, Complex[] x)=>SolveUpper(U, x.AsSpan());
+
+        /// <summary>
+        /// Solve an upper triangular system by backward elimination, Ux=b.
+        /// </summary>
+        /// <param name="U"></param>
+        /// <param name="x"></param>
+        /// <returns></returns>
+        public static void SolveUpper(CompressedColumnStorage<Complex> U, Span<Complex> x)
         {
             int p, j, k, n = U.ColumnCount;
 
@@ -95,7 +120,15 @@ namespace CSparse.Complex
         /// <param name="U"></param>
         /// <param name="x"></param>
         /// <returns></returns>
-        public static void SolveUpperTranspose(CompressedColumnStorage<Complex> U, Complex[] x)
+        public static void SolveUpperTranspose(CompressedColumnStorage<Complex> U, Complex[] x) => SolveUpperTranspose(U, x.AsSpan());
+
+        /// <summary>
+        /// Solve U'x=b where x and b are dense.
+        /// </summary>
+        /// <param name="U"></param>
+        /// <param name="x"></param>
+        /// <returns></returns>
+        public static void SolveUpperTranspose(CompressedColumnStorage<Complex> U, Span<Complex> x)
         {
             int p, j, k, n = U.ColumnCount;
 

--- a/CSparse/Complex/SparseMatrix.cs
+++ b/CSparse/Complex/SparseMatrix.cs
@@ -162,7 +162,7 @@ namespace CSparse.Complex
         #region Linear Algebra (Vector)
 
         /// <inheritdoc />
-        public override void Multiply(Complex[] x, Complex[] y)
+        public override void Multiply(ReadOnlySpan<Complex> x, Span<Complex> y)
         {
             var ax = this.Values;
             var ap = this.ColumnPointers;
@@ -189,7 +189,7 @@ namespace CSparse.Complex
         }
 
         /// <inheritdoc />
-        public override void Multiply(Complex alpha, Complex[] x, Complex beta, Complex[] y)
+        public override void Multiply(Complex alpha, ReadOnlySpan<Complex> x, Complex beta, Span<Complex> y)
         {
             var ax = this.Values;
             var ap = this.ColumnPointers;
@@ -218,7 +218,7 @@ namespace CSparse.Complex
         }
 
         /// <inheritdoc />
-        public override void TransposeMultiply(Complex[] x, Complex[] y)
+        public override void TransposeMultiply(ReadOnlySpan<Complex> x, Span<Complex> y)
         {
             var ax = this.Values;
             var ap = this.ColumnPointers;
@@ -242,7 +242,7 @@ namespace CSparse.Complex
         }
 
         /// <inheritdoc />
-        public override void TransposeMultiply(Complex alpha, Complex[] x, Complex beta, Complex[] y)
+        public override void TransposeMultiply(Complex alpha, ReadOnlySpan<Complex> x, Complex beta, Span<Complex> y)
         {
             var ax = this.Values;
             var ap = this.ColumnPointers;

--- a/CSparse/Double/DenseMatrix.cs
+++ b/CSparse/Double/DenseMatrix.cs
@@ -107,7 +107,7 @@ namespace CSparse.Double
         }
 
         /// <inheritdoc />
-        public override void Multiply(double[] x, double[] y)
+        public override void Multiply(ReadOnlySpan<double> x, Span<double> y)
         {
             var A = Values;
 
@@ -128,7 +128,7 @@ namespace CSparse.Double
         }
 
         /// <inheritdoc />
-        public override void Multiply(double alpha, double[] x, double beta, double[] y)
+        public override void Multiply(double alpha, ReadOnlySpan<double> x, double beta, Span<double> y)
         {
             var A = Values;
 
@@ -149,7 +149,7 @@ namespace CSparse.Double
         }
 
         /// <inheritdoc />
-        public override void TransposeMultiply(double[] x, double[] y)
+        public override void TransposeMultiply(ReadOnlySpan<double> x, Span<double> y)
         {
             var A = Values;
 
@@ -172,7 +172,7 @@ namespace CSparse.Double
         }
 
         /// <inheritdoc />
-        public override void TransposeMultiply(double alpha, double[] x, double beta, double[] y)
+        public override void TransposeMultiply(double alpha, ReadOnlySpan<double> x, double beta, Span<double> y)
         {
             var A = Values;
 

--- a/CSparse/Double/Factorization/SparseCholesky.cs
+++ b/CSparse/Double/Factorization/SparseCholesky.cs
@@ -110,7 +110,14 @@ namespace CSparse.Double.Factorization
         /// </summary>
         /// <param name="input">The right hand side vector, <c>b</c>.</param>
         /// <param name="result">The left hand side vector, <c>x</c>.</param>
-        public void Solve(double[] input, double[] result)
+        public void Solve(double[] input, double[] result) => Solve(input.AsSpan(), result.AsSpan());
+
+        /// <summary>
+        /// Solves a system of linear equations, <c>Ax = b</c>.
+        /// </summary>
+        /// <param name="input">The right hand side vector, <c>b</c>.</param>
+        /// <param name="result">The left hand side vector, <c>x</c>.</param>
+        public void Solve(ReadOnlySpan<double> input, Span<double> result)
         {
             if (input == null) throw new ArgumentNullException(nameof(input));
 

--- a/CSparse/Double/Factorization/SparseLDL.cs
+++ b/CSparse/Double/Factorization/SparseLDL.cs
@@ -116,7 +116,14 @@ namespace CSparse.Double.Factorization
         /// </summary>
         /// <param name="input">Right hand side b.</param>
         /// <param name="result">Solution vector x.</param>
-        public void Solve(double[] input, double[] result)
+        public void Solve(double[] input, double[] result) => Solve(input.AsSpan(), result.AsSpan());
+
+        /// <summary>
+        /// Solves a linear system Ax=b, where A is symmetric positive definite.
+        /// </summary>
+        /// <param name="input">Right hand side b.</param>
+        /// <param name="result">Solution vector x.</param>
+        public void Solve(ReadOnlySpan<double> input, Span<double> result)
         {
             if (input == null) throw new ArgumentNullException(nameof(input));
 

--- a/CSparse/Double/Factorization/SparseLU.cs
+++ b/CSparse/Double/Factorization/SparseLU.cs
@@ -114,7 +114,14 @@ namespace CSparse.Double.Factorization
         /// </summary>
         /// <param name="input">The right hand side vector, <c>b</c>.</param>
         /// <param name="result">The left hand side vector, <c>x</c>.</param>
-        public void Solve(double[] input, double[] result)
+        public void Solve(double[] input, double[] result) => Solve(input.AsSpan(), result.AsSpan());
+
+        /// <summary>
+        /// Solves a system of linear equations, <c>Ax = b</c>.
+        /// </summary>
+        /// <param name="input">The right hand side vector, <c>b</c>.</param>
+        /// <param name="result">The left hand side vector, <c>x</c>.</param>
+        public void Solve(ReadOnlySpan<double> input, Span<double> result)
         {
             if (input == null) throw new ArgumentNullException(nameof(input));
 
@@ -136,7 +143,14 @@ namespace CSparse.Double.Factorization
         /// </summary>
         /// <param name="input">The right hand side vector, <c>b</c>.</param>
         /// <param name="result">The left hand side vector, <c>x</c>.</param>
-        public void SolveTranspose(double[] input, double[] result)
+        public void SolveTranspose(double[] input, double[] result)=>SolveTranspose(input.AsSpan(), result.AsSpan());
+
+        /// <summary>
+        /// Solves a system of linear equations, <c>A'x = b</c>.
+        /// </summary>
+        /// <param name="input">The right hand side vector, <c>b</c>.</param>
+        /// <param name="result">The left hand side vector, <c>x</c>.</param>
+        public void SolveTranspose(ReadOnlySpan<double> input, Span<double> result)
         {
             if (input == null) throw new ArgumentNullException(nameof(input));
 

--- a/CSparse/Double/Factorization/SparseQR.cs
+++ b/CSparse/Double/Factorization/SparseQR.cs
@@ -85,7 +85,18 @@ namespace CSparse.Double.Factorization
         /// Let A be a m-by-n matrix. If m >= n a least-squares problem (min |Ax-b|)
         /// is solved. If m &lt; n the underdetermined system is solved.
         /// </remarks>
-        public override void Solve(double[] input, double[] result)
+        public override void Solve(double[] input, double[] result) => Solve(input.AsSpan(), result.AsSpan());
+
+        /// <summary>
+        /// Solves a system of linear equations, <c>Ax = b</c>.
+        /// </summary>
+        /// <param name="input">The right hand side vector, <c>b</c>.</param>
+        /// <param name="result">The left hand side vector, <c>x</c>.</param>
+        /// <remarks>
+        /// Let A be a m-by-n matrix. If m >= n a least-squares problem (min |Ax-b|)
+        /// is solved. If m &lt; n the underdetermined system is solved.
+        /// </remarks>
+        public override void Solve(ReadOnlySpan<double> input, Span<double> result)
         {
             if (input == null) throw new ArgumentNullException(nameof(input));
 
@@ -127,13 +138,19 @@ namespace CSparse.Double.Factorization
             }
         }
 
+        /// <summary>
+        /// Solves a system of linear equations, <c>A'x = b</c>.
+        /// </summary>
+        /// <param name="input">The right hand side vector, <c>b</c>.</param>
+        /// <param name="result">The left hand side vector, <c>x</c>.</param>
+        public void SolveTranspose(double[] input, double[] result) => SolveTranspose(input.AsSpan(), result.AsSpan());
 
         /// <summary>
         /// Solves a system of linear equations, <c>A'x = b</c>.
         /// </summary>
         /// <param name="input">The right hand side vector, <c>b</c>.</param>
         /// <param name="result">The left hand side vector, <c>x</c>.</param>
-        public void SolveTranspose(double[] input, double[] result)
+        public void SolveTranspose(ReadOnlySpan<double> input, Span<double> result)
         {
             if (input == null) throw new ArgumentNullException(nameof(input));
 

--- a/CSparse/Double/SolverHelper.cs
+++ b/CSparse/Double/SolverHelper.cs
@@ -1,6 +1,7 @@
 namespace CSparse.Double
 {
     using CSparse.Storage;
+    using System;
 
     /// <summary>
     /// Helper methods for solving triangular systems.
@@ -13,7 +14,15 @@ namespace CSparse.Double
         /// <param name="L"></param>
         /// <param name="x"></param>
         /// <returns></returns>
-        public static void SolveLower(CompressedColumnStorage<double> L, double[] x)
+        public static void SolveLower(CompressedColumnStorage<double> L, double[] x) => SolveLower(L, x.AsSpan());
+
+        /// <summary>
+        /// Solve a lower triangular system by forward elimination, Lx=b.
+        /// </summary>
+        /// <param name="L"></param>
+        /// <param name="x"></param>
+        /// <returns></returns>
+        public static void SolveLower(CompressedColumnStorage<double> L, Span<double> x)
         {
             int p, j, k, n = L.ColumnCount;
 
@@ -40,7 +49,15 @@ namespace CSparse.Double
         /// <param name="L"></param>
         /// <param name="x"></param>
         /// <returns></returns>
-        public static void SolveLowerTranspose(CompressedColumnStorage<double> L, double[] x)
+        public static void SolveLowerTranspose(CompressedColumnStorage<double> L, double[] x) => SolveLowerTranspose(L, x.AsSpan());
+
+        /// <summary>
+        /// Solve L'x=b where x and b are dense.
+        /// </summary>
+        /// <param name="L"></param>
+        /// <param name="x"></param>
+        /// <returns></returns>
+        public static void SolveLowerTranspose(CompressedColumnStorage<double> L, Span<double> x)
         {
             int p, j, k, n = L.ColumnCount;
 
@@ -67,7 +84,15 @@ namespace CSparse.Double
         /// <param name="U"></param>
         /// <param name="x"></param>
         /// <returns></returns>
-        public static void SolveUpper(CompressedColumnStorage<double> U, double[] x)
+        public static void SolveUpper(CompressedColumnStorage<double> U, double[] x) => SolveUpper(U, x.AsSpan());
+
+        /// <summary>
+        /// Solve an upper triangular system by backward elimination, Ux=b.
+        /// </summary>
+        /// <param name="U"></param>
+        /// <param name="x"></param>
+        /// <returns></returns>
+        public static void SolveUpper(CompressedColumnStorage<double> U, Span<double> x)
         {
             int p, j, k, n = U.ColumnCount;
 
@@ -94,7 +119,15 @@ namespace CSparse.Double
         /// <param name="U"></param>
         /// <param name="x"></param>
         /// <returns></returns>
-        public static void SolveUpperTranspose(CompressedColumnStorage<double> U, double[] x)
+        public static void SolveUpperTranspose(CompressedColumnStorage<double> U, double[] x) => SolveUpperTranspose(U, x.AsSpan());
+
+        /// <summary>
+        /// Solve U'x=b where x and b are dense.
+        /// </summary>
+        /// <param name="U"></param>
+        /// <param name="x"></param>
+        /// <returns></returns>
+        public static void SolveUpperTranspose(CompressedColumnStorage<double> U, Span<double> x)
         {
             int p, j, k, n = U.ColumnCount;
 

--- a/CSparse/Double/SparseMatrix.cs
+++ b/CSparse/Double/SparseMatrix.cs
@@ -162,7 +162,7 @@ namespace CSparse.Double
         #region Linear Algebra (Vector)
 
         /// <inheritdoc />
-        public override void Multiply(double[] x, double[] y)
+        public override void Multiply(ReadOnlySpan<double> x, Span<double> y)
         {
             var ax = this.Values;
             var ap = this.ColumnPointers;
@@ -189,7 +189,7 @@ namespace CSparse.Double
         }
 
         /// <inheritdoc />
-        public override void Multiply(double alpha, double[] x, double beta, double[] y)
+        public override void Multiply(double alpha, ReadOnlySpan<double> x, double beta, Span<double> y)
         {
             var ax = this.Values;
             var ap = this.ColumnPointers;
@@ -218,7 +218,7 @@ namespace CSparse.Double
         }
 
         /// <inheritdoc />
-        public override void TransposeMultiply(double[] x, double[] y)
+        public override void TransposeMultiply(ReadOnlySpan<double> x, Span<double> y)
         {
             var ax = this.Values;
             var ap = this.ColumnPointers;
@@ -242,7 +242,7 @@ namespace CSparse.Double
         }
 
         /// <inheritdoc />
-        public override void TransposeMultiply(double alpha, double[] x, double beta, double[] y)
+        public override void TransposeMultiply(double alpha, ReadOnlySpan<double> x, double beta, Span<double> y)
         {
             var ax = this.Values;
             var ap = this.ColumnPointers;

--- a/CSparse/Factorization/ISolver.cs
+++ b/CSparse/Factorization/ISolver.cs
@@ -14,5 +14,12 @@ namespace CSparse.Factorization
         /// <param name="input">Right hand side b</param>
         /// <param name="result">Solution vector x.</param>
         void Solve(T[] input, T[] result);
+
+        /// <summary>
+        /// Solves a system of linear equations, Ax = b.
+        /// </summary>
+        /// <param name="input">Right hand side b</param>
+        /// <param name="result">Solution vector x.</param>
+        void Solve(ReadOnlySpan<T> input, Span<T> result);
     }
 }

--- a/CSparse/Factorization/SparseQR.cs
+++ b/CSparse/Factorization/SparseQR.cs
@@ -40,6 +40,13 @@ namespace CSparse.Factorization
         public abstract void Solve(T[] input, T[] result);
 
         /// <summary>
+        /// Solves a linear system Ax=b.
+        /// </summary>
+        /// <param name="input">Right hand side b.</param>
+        /// <param name="result">Solution vector x.</param>
+        public abstract void Solve(ReadOnlySpan<T> input, Span<T> result);
+
+        /// <summary>
         /// Create a Householder reflection.
         /// </summary>
         protected abstract T CreateHouseholder(T[] x, int offset, ref double beta, int n);

--- a/CSparse/ILinearOperator.cs
+++ b/CSparse/ILinearOperator.cs
@@ -26,6 +26,13 @@ namespace CSparse
         void Multiply(T[] x, T[] y);
 
         /// <summary>
+        /// Multiplies a (m-by-n) matrix by a vector, y = A*x. 
+        /// </summary>
+        /// <param name="x">Vector of length n (column count).</param>
+        /// <param name="y">Vector of length m (row count), containing the result.</param>
+        void Multiply(ReadOnlySpan<T> x, Span<T> y);
+
+        /// <summary>
         /// Multiplies a (m-by-n) matrix by a vector, y = alpha * A * x + beta * y.
         /// </summary>
         /// <param name="alpha">Scaling factor fo vertor x.</param>
@@ -38,11 +45,30 @@ namespace CSparse
         void Multiply(T alpha, T[] x, T beta, T[] y);
 
         /// <summary>
+        /// Multiplies a (m-by-n) matrix by a vector, y = alpha * A * x + beta * y.
+        /// </summary>
+        /// <param name="alpha">Scaling factor fo vertor x.</param>
+        /// <param name="x">Vector of length n (column count).</param>
+        /// <param name="beta">Scaling factor fo vertor y.</param>
+        /// <param name="y">Vector of length m (row count), containing the result.</param>
+        /// <remarks>
+        /// Input values of vector <paramref name="y"/> will be accumulated.
+        /// </remarks>
+        void Multiply(T alpha, ReadOnlySpan<T> x, T beta, Span<T> y);
+
+        /// <summary>
         /// Multiplies the transpose of a (m-by-n) matrix by a vector, y = A'*x. 
         /// </summary>
         /// <param name="x">Vector of length m (column count of A').</param>
         /// <param name="y">Vector of length n (row count of A'), containing the result.</param>
         void TransposeMultiply(T[] x, T[] y);
+
+        /// <summary>
+        /// Multiplies the transpose of a (m-by-n) matrix by a vector, y = A'*x. 
+        /// </summary>
+        /// <param name="x">Vector of length m (column count of A').</param>
+        /// <param name="y">Vector of length n (row count of A'), containing the result.</param>
+        void TransposeMultiply(ReadOnlySpan<T> x, Span<T> y);
 
         /// <summary>
         /// Multiplies the transpose of a (m-by-n) matrix by a vector, y = alpha * A^t * x + beta * y.
@@ -55,5 +81,17 @@ namespace CSparse
         /// Input values of vector <paramref name="y"/> will be accumulated.
         /// </remarks>
         void TransposeMultiply(T alpha, T[] x, T beta, T[] y);
+
+        /// <summary>
+        /// Multiplies the transpose of a (m-by-n) matrix by a vector, y = alpha * A^t * x + beta * y.
+        /// </summary>
+        /// <param name="alpha">Scaling factor fo vertor x.</param>
+        /// <param name="x">Vector of length m (column count of A').</param>
+        /// <param name="beta">Scaling factor fo vertor y.</param>
+        /// <param name="y">Vector of length n (row count of A'), containing the result.</param>
+        /// <remarks>
+        /// Input values of vector <paramref name="y"/> will be accumulated.
+        /// </remarks>
+        void TransposeMultiply(T alpha, ReadOnlySpan<T> x, T beta, Span<T> y);
     }
 }

--- a/CSparse/Matrix.cs
+++ b/CSparse/Matrix.cs
@@ -82,7 +82,14 @@ namespace CSparse
         /// </summary>
         /// <param name="rowIndex">The column index to extract.</param>
         /// <param name="target">Dense array.</param>
-        public abstract void Row(int rowIndex, T[] target);
+        public void Row(int rowIndex, T[] target) => Row(rowIndex, target.AsSpan());
+
+        /// <summary>
+        /// Extract row from matrix.
+        /// </summary>
+        /// <param name="rowIndex">The column index to extract.</param>
+        /// <param name="target">Dense array.</param>
+        public abstract void Row(int rowIndex, Span<T> target);
 
         /// <summary>
         /// Extract column from matrix.
@@ -95,7 +102,14 @@ namespace CSparse
         /// </summary>
         /// <param name="columnIndex">The column index to extract.</param>
         /// <param name="target">Dense array.</param>
-        public abstract void Column(int columnIndex, T[] target);
+        public void Column(int columnIndex, T[] target) => Column(columnIndex, target.AsSpan());
+
+        /// <summary>
+        /// Extract column from matrix.
+        /// </summary>
+        /// <param name="columnIndex">The column index to extract.</param>
+        /// <param name="target">Dense array.</param>
+        public abstract void Column(int columnIndex, Span<T> target);
 
         /// <summary>
         /// Calculates the induced L1 norm of this matrix.
@@ -128,16 +142,28 @@ namespace CSparse
         public abstract void EnumerateIndexed(Action<int, int, T> action);
 
         /// <inheritdoc />
-        public abstract void Multiply(T[] x, T[] y);
+        public void Multiply(T[] x, T[] y) => Multiply(x.AsSpan(), y.AsSpan());
 
         /// <inheritdoc />
-        public abstract void Multiply(T alpha, T[] x, T beta, T[] y);
+        public abstract void Multiply(ReadOnlySpan<T> x, Span<T> y);
 
         /// <inheritdoc />
-        public abstract void TransposeMultiply(T[] x, T[] y);
+        public void Multiply(T alpha, T[] x, T beta, T[] y) => Multiply(alpha, x.AsSpan(), beta, y.AsSpan());
 
         /// <inheritdoc />
-        public abstract void TransposeMultiply(T alpha, T[] x, T beta, T[] y);
+        public abstract void Multiply(T alpha, ReadOnlySpan<T> x, T beta, Span<T> y);
+
+        /// <inheritdoc />
+        public void TransposeMultiply(T[] x, T[] y) => TransposeMultiply(x.AsSpan(), y.AsSpan());
+
+        /// <inheritdoc />
+        public abstract void TransposeMultiply(ReadOnlySpan<T> x, Span<T> y);
+
+        /// <inheritdoc />
+        public void TransposeMultiply(T alpha, T[] x, T beta, T[] y) => TransposeMultiply(alpha, x.AsSpan(), beta, y.AsSpan());
+
+        /// <inheritdoc />
+        public abstract void TransposeMultiply(T alpha, ReadOnlySpan<T> x, T beta, Span<T> y);
 
         #region Storage equality
 
@@ -205,6 +231,7 @@ namespace CSparse
             }
             return hash;
         }
+
 
         #endregion
     }

--- a/CSparse/Permutation.cs
+++ b/CSparse/Permutation.cs
@@ -19,9 +19,24 @@ namespace CSparse
         /// </remarks>
         public static void Apply<T>(int[] p, T[] b, T[] x, int n)
         {
+            Apply(p, b, x, n);
+        }
+
+        /// <summary>
+        /// Permutes a vector, x=P*b.
+        /// </summary>
+        /// <param name="p">Permutation vector.</param>
+        /// <param name="b">Input vector.</param>
+        /// <param name="x">Output vector, x=P*b.</param>
+        /// <param name="n">Length of p, b and x.</param>
+        /// <remarks>
+        /// p = null denotes identity.
+        /// </remarks>
+        public static void Apply<T>(int[] p, ReadOnlySpan<T> b, Span<T> x, int n)
+        {
             if (p == null)
             {
-                Array.Copy(b, x, n);
+                b.Slice(0, n).CopyTo(x);
             }
             else
             {
@@ -44,9 +59,24 @@ namespace CSparse
         /// </remarks>
         public static void ApplyInverse<T>(int[] p, T[] b, T[] x, int n)
         {
+            ApplyInverse(p, b, x, n);
+        }
+
+        /// <summary>
+        /// Permutes a vector, x = P'b.
+        /// </summary>
+        /// <param name="p">Permutation vector.</param>
+        /// <param name="b">Input vector.</param>
+        /// <param name="x">Output vector, x = P'b.</param>
+        /// <param name="n">Length of p, b, and x.</param>
+        /// <remarks>
+        /// p = null denotes identity.
+        /// </remarks>
+        public static void ApplyInverse<T>(int[] p, ReadOnlySpan<T> b, Span<T> x, int n)
+        {
             if (p == null)
             {
-                Array.Copy(b, x, n);
+                b.Slice(0, n).CopyTo(x);
             }
             else
             {

--- a/CSparse/Storage/CompressedColumnStorage.cs
+++ b/CSparse/Storage/CompressedColumnStorage.cs
@@ -315,7 +315,7 @@ namespace CSparse.Storage
         }
 
         /// <inheritdoc />
-        public override void Row(int rowIndex, T[] target)
+        public override void Row(int rowIndex, Span<T> target)
         {
             if (target.Length != columns)
             {
@@ -349,7 +349,7 @@ namespace CSparse.Storage
         }
 
         /// <inheritdoc />
-        public override void Column(int columnIndex, T[] target)
+        public override void Column(int columnIndex, Span<T> target)
         {
             if (target.Length != RowCount)
             {

--- a/CSparse/Storage/DenseColumnMajorStorage.cs
+++ b/CSparse/Storage/DenseColumnMajorStorage.cs
@@ -235,7 +235,7 @@ namespace CSparse.Storage
         }
 
         /// <inheritdoc />
-        public override void Row(int row, T[] target)
+        public override void Row(int row, Span<T> target)
         {
             for (int i = 0; i < columns; i++)
             {
@@ -244,9 +244,9 @@ namespace CSparse.Storage
         }
 
         /// <inheritdoc />
-        public override void Column(int column, T[] target)
+        public override void Column(int column, Span<T> target)
         {
-            Array.Copy(Values, column * rows, target, 0, rows);
+            Values.AsSpan().Slice(column * rows, rows).CopyTo(target);
         }
 
         /// <summary>


### PR DESCRIPTION
Functions that take T[] as an argument that can be explicitly replaced by Span<T> have been rewritten. Also, T[] is assumed to be an overload of Span<T>.
However, this change requires a reference to System.Memory.dll.