### PR TITLE
Add ValueTuple overload for creating CompressedColumnStorage

### DIFF
--- a/CSparse/Converter.cs
+++ b/CSparse/Converter.cs
@@ -289,5 +289,25 @@ namespace CSparse
 
             return storage;
         }
+
+        /// <summary>
+        /// Convert a row major array to coordinate storage.
+        /// </summary>
+        /// <param name="enumerable">Enumerates the entries of a matrix with value tuples.</param>
+        /// <param name="rowCount">Number of rows.</param>
+        /// <param name="columnCount">Number of columns.</param>
+        /// <returns>Coordinate storage.</returns>
+        public static CoordinateStorage<T> FromEnumerable<T>(IEnumerable<(int, int, T)> enumerable, int rowCount, int columnCount)
+            where T : struct, IEquatable<T>, IFormattable
+        {
+            var storage = new CoordinateStorage<T>(rowCount, columnCount, Math.Max(rowCount, columnCount));
+
+            foreach (var item in enumerable)
+            {
+                storage.At(item.Item1, item.Item2, item.Item3);
+            }
+
+            return storage;
+        }
     }
 }

--- a/CSparse/Converter.cs
+++ b/CSparse/Converter.cs
@@ -297,14 +297,14 @@ namespace CSparse
         /// <param name="rowCount">Number of rows.</param>
         /// <param name="columnCount">Number of columns.</param>
         /// <returns>Coordinate storage.</returns>
-        public static CoordinateStorage<T> FromEnumerable<T>(IEnumerable<(int, int, T)> enumerable, int rowCount, int columnCount)
+        public static CoordinateStorage<T> FromEnumerable<T>(IEnumerable<(int row, int column, T value)> enumerable, int rowCount, int columnCount)
             where T : struct, IEquatable<T>, IFormattable
         {
             var storage = new CoordinateStorage<T>(rowCount, columnCount, Math.Max(rowCount, columnCount));
 
             foreach (var item in enumerable)
             {
-                storage.At(item.Item1, item.Item2, item.Item3);
+                storage.At(item.row, item.column, item.value);
             }
 
             return storage;

--- a/CSparse/Matrix.cs
+++ b/CSparse/Matrix.cs
@@ -132,9 +132,18 @@ namespace CSparse
         /// <summary>
         /// Enumerates all values of the matrix.
         /// </summary>
+        /// <remarks>
+        /// <see cref="EnumerateIndexedAsValueTuples"/> for a version that returns stack-allocated value tuples to save transient heap allocations (saves performance overhead of allocations + garbage collection) of the <see cref="Tuple"/> class.
+        /// </remarks>
         /// <returns>Enumeration of tuples (i, j, a[i, j]).</returns>
         public abstract IEnumerable<Tuple<int, int, T>> EnumerateIndexed();
 
+        /// <summary>
+        /// Enumerates all values of the matrix, but returns as stack-allocated value tuples instead of heap-allocated tuples.
+        /// </summary>
+        /// <returns>Enumeration of tuples (i, j, a[i, j]).</returns>
+        public abstract IEnumerable<(int row, int column, T value)> EnumerateIndexedAsValueTuples();
+       
         /// <summary>
         /// Enumerates all values of the matrix.
         /// </summary>

--- a/CSparse/Storage/CompressedColumnStorage.cs
+++ b/CSparse/Storage/CompressedColumnStorage.cs
@@ -156,7 +156,7 @@ namespace CSparse.Storage
         /// <summary>
         /// Create a new sparse matrix as a copy of the given indexed enumerable using a value tuple.
         /// </summary>
-        public static CompressedColumnStorage<T> OfIndexed(int rows, int columns, IEnumerable<(int, int, T)> enumerable)
+        public static CompressedColumnStorage<T> OfIndexed(int rows, int columns, IEnumerable<(int row, int column, T value)> enumerable)
         {
             var c = Converter.FromEnumerable<T>(enumerable, rows, columns);
 

--- a/CSparse/Storage/CompressedColumnStorage.cs
+++ b/CSparse/Storage/CompressedColumnStorage.cs
@@ -154,6 +154,16 @@ namespace CSparse.Storage
         }
 
         /// <summary>
+        /// Create a new sparse matrix as a copy of the given indexed enumerable using a value tuple.
+        /// </summary>
+        public static CompressedColumnStorage<T> OfIndexed(int rows, int columns, IEnumerable<(int, int, T)> enumerable)
+        {
+            var c = Converter.FromEnumerable<T>(enumerable, rows, columns);
+
+            return Converter.ToCompressedColumnStorage(c);
+        }
+
+        /// <summary>
         /// Create a new sparse matrix as a copy of the given array (row-major).
         /// </summary>
         public static CompressedColumnStorage<T> OfRowMajor(int rows, int columns, T[] rowMajor)

--- a/CSparse/Storage/CompressedColumnStorage.cs
+++ b/CSparse/Storage/CompressedColumnStorage.cs
@@ -110,7 +110,7 @@ namespace CSparse.Storage
         /// </summary>
         public static CompressedColumnStorage<T> OfMatrix(Matrix<T> matrix)
         {
-            var c = Converter.FromEnumerable<T>(matrix.EnumerateIndexed(), matrix.RowCount, matrix.ColumnCount);
+            var c = Converter.FromEnumerable<T>(matrix.EnumerateIndexedAsValueTuples(), matrix.RowCount, matrix.ColumnCount);
 
             return Converter.ToCompressedColumnStorage(c);
         }
@@ -581,6 +581,15 @@ namespace CSparse.Storage
         /// <inheritdoc />
         public override IEnumerable<Tuple<int, int, T>> EnumerateIndexed()
         {
+            foreach (var valueTuple in EnumerateIndexedAsValueTuples())
+            {
+                yield return Tuple.Create(valueTuple.row, valueTuple.column, valueTuple.value);
+            }
+        }
+
+        /// <inheritdoc />
+        public override IEnumerable<(int row, int column, T value)> EnumerateIndexedAsValueTuples()
+        {
             var ax = Values;
             var ap = ColumnPointers;
             var ai = RowIndices;
@@ -590,7 +599,7 @@ namespace CSparse.Storage
                 var end = ap[i + 1];
                 for (var j = ap[i]; j < end; j++)
                 {
-                    yield return new Tuple<int, int, T>(ai[j], i, ax[j]);
+                    yield return (ai[j], i, ax[j]);
                 }
             }
         }

--- a/CSparse/Storage/CompressedColumnStorage.cs
+++ b/CSparse/Storage/CompressedColumnStorage.cs
@@ -146,6 +146,9 @@ namespace CSparse.Storage
         /// <summary>
         /// Create a new sparse matrix as a copy of the given indexed enumerable.
         /// </summary>
+        /// <param name="rows">The number of rows.</param>
+        /// <param name="columns">The number of columns.</param>
+        /// <param name="enumerable">Tuples with the three elements of row, column, and the value that belongs at that position.</param>
         public static CompressedColumnStorage<T> OfIndexed(int rows, int columns, IEnumerable<Tuple<int, int, T>> enumerable)
         {
             var c = Converter.FromEnumerable<T>(enumerable, rows, columns);
@@ -156,6 +159,9 @@ namespace CSparse.Storage
         /// <summary>
         /// Create a new sparse matrix as a copy of the given indexed enumerable using a value tuple.
         /// </summary>
+        /// <param name="rows">The number of rows.</param>
+        /// <param name="columns">The number of columns.</param>
+        /// <param name="enumerable">Value tuples with the three elements of row, column, and the value that belongs at that position.</param>
         public static CompressedColumnStorage<T> OfIndexed(int rows, int columns, IEnumerable<(int row, int column, T value)> enumerable)
         {
             var c = Converter.FromEnumerable<T>(enumerable, rows, columns);

--- a/CSparse/Storage/DenseColumnMajorStorage.cs
+++ b/CSparse/Storage/DenseColumnMajorStorage.cs
@@ -166,7 +166,7 @@ namespace CSparse.Storage
             int order = diagonal.Length;
 
             var A = Create(order, order);
-            
+
             for (int i = 0; i < order; i++)
             {
                 A.At(i, i, diagonal[i]);
@@ -548,11 +548,20 @@ namespace CSparse.Storage
         /// <inheritdoc />
         public override IEnumerable<Tuple<int, int, T>> EnumerateIndexed()
         {
+            foreach (var valueTuple in EnumerateIndexedAsValueTuples())
+            {
+                yield return Tuple.Create(valueTuple.row, valueTuple.column, valueTuple.value);
+            }
+        }
+
+        /// <inheritdoc />
+        public override IEnumerable<(int row, int column, T value)> EnumerateIndexedAsValueTuples()
+        {
             for (int row = 0; row < rows; row++)
             {
                 for (int column = 0; column < columns; column++)
                 {
-                    yield return new Tuple<int, int, T>(row, column, Values[(column * rows) + row]);
+                    yield return (row, column, Values[(column * rows) + row]);
                 }
             }
         }


### PR DESCRIPTION
When working with this package, I wanted to use ValueTuple over classic Tuple to avoid the heap allocation that occurs on every single Tuple (improving performance).