### PR TITLE
Reuse factor buffers across re-factorizations (follow-up to #55)

### DIFF
--- a/CSparse.Tests/Double/Factorization/SparseLUTest.cs
+++ b/CSparse.Tests/Double/Factorization/SparseLUTest.cs
@@ -2,6 +2,7 @@ namespace CSparse.Tests.Double.Factorization
 {
     using CSparse.Double;
     using CSparse.Double.Factorization;
+    using CSparse.Storage;
     using NUnit.Framework;
     using System;
 
@@ -108,6 +109,40 @@ namespace CSparse.Tests.Double.Factorization
             // Dimension guard.
             var small = new SparseMatrix(3, 3, 0);
             Assert.Throws<ArgumentException>(() => lu.Refactorize(small, 1.0));
+        }
+
+        [Test]
+        public void TestRefactorizeNoTrim()
+        {
+            // With AutoTrimStorage disabled, the L/U buffers are kept across
+            // re-factorizations (no Resize(0) trim) — the result must stay correct.
+            var trim = CompressedColumnStorage<double>.AutoTrimStorage;
+            try
+            {
+                CompressedColumnStorage<double>.AutoTrimStorage = false;
+
+                var A = ResourceLoader.Get<double>("general-40x40.mat");
+                var lu = SparseLU.Create(A, ColumnOrdering.MinimumDegreeAtPlusA, 1.0);
+
+                var B = A.Clone();
+                var bv = B.Values;
+                for (int i = 0; i < bv.Length; i++) bv[i] *= 2.0;
+
+                lu.Refactorize(B, 1.0);
+
+                var x = Helper.CreateTestVector(B.ColumnCount);
+                var b = Helper.Multiply(B, x);
+                var r = Vector.Clone(b);
+
+                lu.Solve(b, x);
+                B.Multiply(-1.0, x, 1.0, r);
+
+                Assert.That(Vector.Norm(r.Length, r) < EPS, Is.True);
+            }
+            finally
+            {
+                CompressedColumnStorage<double>.AutoTrimStorage = trim;
+            }
         }
     }
 }

--- a/CSparse/Complex/Factorization/SparseCholesky.cs
+++ b/CSparse/Complex/Factorization/SparseCholesky.cs
@@ -286,7 +286,15 @@ namespace CSparse.Complex.Factorization
             var ci = C.RowIndices;
             var cx = C.Values;
 
-            this.L = CompressedColumnStorage<Complex>.Create(n, n, colp[n]);
+            if (this.L is null)
+            {
+                this.L = CompressedColumnStorage<Complex>.Create(n, n, colp[n]);
+            }
+            else
+            {
+                // Re-factorization (same pattern) : reuse the existing buffer.
+                this.L.Clear();
+            }
 
             var lp = L.ColumnPointers;
             var li = L.RowIndices;

--- a/CSparse/Complex/Factorization/SparseLDL.cs
+++ b/CSparse/Complex/Factorization/SparseLDL.cs
@@ -276,8 +276,16 @@ namespace CSparse.Complex.Factorization
             int[] P = S.q;
             int[] Pinv = S.pinv;
 
-            this.D = new double[n];
-            this.L = CompressedColumnStorage<Complex>.Create(n, n, S.cp[n]);
+            if (this.L is null)
+            {
+                this.D = new double[n];
+                this.L = CompressedColumnStorage<Complex>.Create(n, n, S.cp[n]);
+            }
+            else
+            {
+                // Re-factorization (same pattern) : reuse the existing buffers.
+                this.L.Clear();
+            }
 
             Array.Copy(S.cp, L.ColumnPointers, n + 1);
 

--- a/CSparse/Complex/Factorization/SparseLU.cs
+++ b/CSparse/Complex/Factorization/SparseLU.cs
@@ -210,9 +210,18 @@ namespace CSparse.Complex.Factorization
             int lnz = S.lnz;
             int unz = S.unz;
 
-            this.L = CompressedColumnStorage<Complex>.Create(n, n, lnz);
-            this.U = CompressedColumnStorage<Complex>.Create(n, n, unz);
-            this.pinv = new int[n];
+            if (this.L is null)
+            {
+                this.L = CompressedColumnStorage<Complex>.Create(n, n, lnz);
+                this.U = CompressedColumnStorage<Complex>.Create(n, n, unz);
+                this.pinv = new int[n];
+            }
+            else
+            {
+                // Re-factorization (same pattern) : reuse the existing buffers.
+                this.L.Clear();
+                this.U.Clear();
+            }
 
             // Workspace
             var x = this.temp;
@@ -325,9 +334,13 @@ namespace CSparse.Complex.Factorization
                 li[p] = pinv[li[p]];
             }
 
-            // Remove extra space from L and U
-            L.Resize(0);
-            U.Resize(0);
+            // Remove extra space from L and U (skipped when trimming is disabled,
+            // e.g. to reuse the buffers across re-factorizations in an iterative solver).
+            if (CompressedColumnStorage<Complex>.AutoTrimStorage)
+            {
+                L.Resize(0);
+                U.Resize(0);
+            }
         }
 
         /// <summary>

--- a/CSparse/Double/Factorization/SparseCholesky.cs
+++ b/CSparse/Double/Factorization/SparseCholesky.cs
@@ -281,7 +281,15 @@ namespace CSparse.Double.Factorization
             var ci = C.RowIndices;
             var cx = C.Values;
 
-            this.L = CompressedColumnStorage<double>.Create(n, n, colp[n]);
+            if (this.L is null)
+            {
+                this.L = CompressedColumnStorage<double>.Create(n, n, colp[n]);
+            }
+            else
+            {
+                // Re-factorization (same pattern) : reuse the existing buffer.
+                this.L.Clear();
+            }
 
             var lp = L.ColumnPointers;
             var li = L.RowIndices;

--- a/CSparse/Double/Factorization/SparseLDL.cs
+++ b/CSparse/Double/Factorization/SparseLDL.cs
@@ -275,8 +275,16 @@ namespace CSparse.Double.Factorization
             int[] P = S.q;
             int[] Pinv = S.pinv;
 
-            this.D = new double[n];
-            this.L = CompressedColumnStorage<double>.Create(n, n, S.cp[n]);
+            if (this.L is null)
+            {
+                this.D = new double[n];
+                this.L = CompressedColumnStorage<double>.Create(n, n, S.cp[n]);
+            }
+            else
+            {
+                // Re-factorization (same pattern) : reuse the existing buffers.
+                this.L.Clear();
+            }
 
             Array.Copy(S.cp, L.ColumnPointers, n + 1);
 

--- a/CSparse/Double/Factorization/SparseLU.cs
+++ b/CSparse/Double/Factorization/SparseLU.cs
@@ -209,9 +209,18 @@ namespace CSparse.Double.Factorization
             int lnz = S.lnz;
             int unz = S.unz;
 
-            this.L = CompressedColumnStorage<double>.Create(n, n, lnz);
-            this.U = CompressedColumnStorage<double>.Create(n, n, unz);
-            this.pinv = new int[n];
+            if (this.L is null)
+            {
+                this.L = CompressedColumnStorage<double>.Create(n, n, lnz);
+                this.U = CompressedColumnStorage<double>.Create(n, n, unz);
+                this.pinv = new int[n];
+            }
+            else
+            {
+                // Re-factorization (same pattern) : reuse the existing buffers.
+                this.L.Clear();
+                this.U.Clear();
+            }
 
             // Workspace
             var x = this.temp;
@@ -324,9 +333,13 @@ namespace CSparse.Double.Factorization
                 li[p] = pinv[li[p]];
             }
 
-            // Remove extra space from L and U
-            L.Resize(0);
-            U.Resize(0);
+            // Remove extra space from L and U (skipped when trimming is disabled,
+            // e.g. to reuse the buffers across re-factorizations in an iterative solver).
+            if (CompressedColumnStorage<double>.AutoTrimStorage)
+            {
+                L.Resize(0);
+                U.Resize(0);
+            }
         }
 
         /// <summary>

--- a/CSparse/Storage/CompressedColumnStorage.cs
+++ b/CSparse/Storage/CompressedColumnStorage.cs
@@ -18,7 +18,10 @@ namespace CSparse.Storage
         /// automatically resized to non-zeros count. Defaults to true.
         /// </summary>
         /// <remarks>
-        /// Affects only sparse matrix addition and multiplication.
+        /// Affects sparse matrix addition and multiplication, and the trimming of
+        /// the L/U factors at the end of <c>SparseLU.Factorize</c>. Set to
+        /// <c>false</c> to keep the factor buffers allocated across repeated
+        /// <c>Refactorize</c> calls (iterative solvers, time-stepping).
         /// </remarks>
         public static bool AutoTrimStorage { get; set; } = true;
 


### PR DESCRIPTION
Follow-up to #55 (merged) — as you suggested, rebased onto current `master` for a clean history.

## What

`SparseLU` / `SparseCholesky` / `SparseLDL` (Double **and** Complex) now allocate `L`/`U`
(and `pinv`, `D`) only on the **first** `Factorize` call, and `Clear()` + reuse the buffers
on subsequent calls (same sparsity pattern). This avoids re-allocating the factor storage
on every `Refactorize` — the point of #55, for Newton / time-stepping loops.

## The `SparseLU` trim (per your note)

You suggested gating the end-of-factorization trim on `AutoTrimStorage` rather than dropping
it — done. `SparseLU.Factorize` now wraps the final `Resize(0)` in
`if (CompressedColumnStorage<T>.AutoTrimStorage)`. So with `AutoTrimStorage = false` the
`L`/`U` buffers stay allocated across `Refactorize` calls → fully allocation-free reuse for
iterative solvers / time-stepping. I updated the `AutoTrimStorage` doc to mention this.
(`Cholesky`/`LDL` allocate the exact factor size, so no trim is involved there.)
